### PR TITLE
Export GraalVM home to environment

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -4984,6 +4984,7 @@ const OPTIONS = {
     binDir   : 'bin',
     appDir   : '/Contents/Home',
     javaHome : 'JAVA_HOME',
+    graalHome : 'GRAALVM_HOME',
 };
 
 const getGraalVM = async (javaVersion, graalvmVersion, options = {}) => {
@@ -5016,9 +5017,11 @@ const getGraalVM = async (javaVersion, graalvmVersion, options = {}) => {
         await Object(io.rmRF)(tempDir);
 
         Object(core.exportVariable)(options.javaHome, Object(external_path_.join)(toolPath, options.appDir));
+        Object(core.exportVariable)(options.graalHome, Object(external_path_.join)(toolPath, options.appDir));
         Object(core.addPath)(Object(external_path_.join)(toolPath, options.appDir, options.binDir));
     } else {
         Object(core.exportVariable)(options.javaHome, toolPath);
+        Object(core.exportVariable)(options.graalHome, toolPath);
         Object(core.addPath)(Object(external_path_.join)(toolPath, options.binDir));
     }
 

--- a/src/installer.js
+++ b/src/installer.js
@@ -15,6 +15,7 @@ const OPTIONS = {
     binDir   : 'bin',
     appDir   : '/Contents/Home',
     javaHome : 'JAVA_HOME',
+    graalHome : 'GRAALVM_HOME',
 };
 
 export const getGraalVM = async (javaVersion, graalvmVersion, options = {}) => {
@@ -47,9 +48,11 @@ export const getGraalVM = async (javaVersion, graalvmVersion, options = {}) => {
         await rmRF(tempDir);
 
         exportVariable(options.javaHome, join(toolPath, options.appDir));
+        exportVariable(options.graalHome, join(toolPath, options.appDir));
         addPath(join(toolPath, options.appDir, options.binDir));
     } else {
         exportVariable(options.javaHome, toolPath);
+        exportVariable(options.graalHome, toolPath);
         addPath(join(toolPath, options.binDir));
     }
 


### PR DESCRIPTION
GRAALVM_HOME variable is required for maven/gradle GraalVM client plugins to work:
[https://docs.gluonhq.com/](https://docs.gluonhq.com/)